### PR TITLE
cleanup deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,9 +16,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "capstone"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1097e608594dad3bad608295567f757742b883606fe150faf7a9740b849730d8"
+checksum = "b08ca438d9585a2b216b0c2e88ea51e096286c5f197f7be2526bb515ef775b6c"
 dependencies = [
  "capstone-sys",
  "libc",
@@ -26,9 +26,9 @@ dependencies = [
 
 [[package]]
 name = "capstone-sys"
-version = "0.15.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e7f651d5ec4c2a2e6c508f2c8032655003cd728ec85663e9796616990e25b5a"
+checksum = "fe7183271711ffb7c63a6480e4baf480e0140da59eeba9b18fcc8bf3478950e3"
 dependencies = [
  "cc",
  "libc",
@@ -138,11 +138,8 @@ version = "1.0.5"
 dependencies = [
  "capstone",
  "cfg-if",
- "errno",
  "iced-x86",
  "jit-allocator",
- "libc",
- "num",
  "num-traits",
  "once_cell",
  "parking_lot",
@@ -159,73 +156,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "num"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
-dependencies = [
- "num-bigint",
- "num-complex",
- "num-integer",
- "num-iter",
- "num-rational",
- "num-traits",
-]
-
-[[package]]
-name = "num-bigint"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93ab6289c7b344a8a9f60f88d80aa20032336fe78da341afc91c8a2341fc75f"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02e0d21255c828d6f128a1e41534206671e8c3ea0c62f32291e808dc82cff17d"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
-name = "num-integer"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
-dependencies = [
- "autocfg",
- "num-traits",
-]
-
-[[package]]
-name = "num-iter"
-version = "0.1.43"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d03e6c028c5dc5cac6e2dec0efda81fc887605bb3d884578bb6d6bf7514e252"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
-name = "num-rational"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
-dependencies = [
- "autocfg",
- "num-bigint",
- "num-integer",
- "num-traits",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -141,8 +141,6 @@ dependencies = [
  "iced-x86",
  "jit-allocator",
  "num-traits",
- "once_cell",
- "parking_lot",
  "paste",
  "pico-args",
  "tinyvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,6 @@ keywords = ["jit", "assembler", "codegen"]
 cfg-if = "1.0.0"
 tinyvec = { version = "1.6", features = ["alloc"] }
 jit-allocator = "0.2.8"
-parking_lot = "0.12"
-once_cell = "1.17"
 num-traits = "0.2"
 capstone = { version = "0.12", optional = true }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,17 +13,17 @@ keywords = ["jit", "assembler", "codegen"]
 [dependencies]
 cfg-if = "1.0.0"
 tinyvec = { version = "1.6", features = ["alloc"] }
-libc = "0.2"
 jit-allocator = "0.2.8"
 parking_lot = "0.12"
 once_cell = "1.17"
 num-traits = "0.2"
-paste = "1.0"
-errno = "0.3"
-num = "0.4"
-capstone = { version = "0.11", optional = true }
+capstone = { version = "0.12", optional = true }
+
 [target.'cfg(target_arch="x86_64")'.dependencies]
 iced-x86 = { version = "1.13", features = ["decoder", "no_std", "gas"], default-features = false, optional = true }
+
+[target.'cfg(target_arch="riscv64")'.dependencies]
+paste = "1.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = [

--- a/src/assembler/riscv64assembler.rs
+++ b/src/assembler/riscv64assembler.rs
@@ -202,7 +202,7 @@ macro_rules! decl_immediate {
         impl $name {
             pub const IMMEDIATE_SIZE: usize = $immediate_size;
 
-            pub fn immediate_mask<T:  num_traits::WrappingSub + num::PrimInt + num::NumCast>() -> T {
+            pub fn immediate_mask<T: num_traits::WrappingSub + num_traits::PrimInt + num_traits::NumCast>() -> T {
                 if $immediate_size < std::mem::size_of::<u32>() * 8 {
                     T::from(1u64.wrapping_shl($immediate_size as u32)).unwrap().wrapping_sub(&T::one())
                 } else {
@@ -210,14 +210,14 @@ macro_rules! decl_immediate {
                 }
             }
 
-            pub fn is_valid<T: num::PrimInt + num::NumCast>(imm_value: T) -> bool {
+            pub fn is_valid<T: num_traits::PrimInt + num_traits::NumCast>(imm_value: T) -> bool {
                 let shift = std::mem::size_of::<T>() * 8 - $immediate_size;
 
 
                 imm_value == T::from((imm_value.to_i64().unwrap() << shift) >> shift).unwrap()
             }
 
-            pub fn v32<T: num::NumCast>(imm_value: i32) -> T {
+            pub fn v32<T: num_traits::NumCast>(imm_value: i32) -> T {
 
                 assert!(Self::is_valid(imm_value), "Invalid immediate value: {}", imm_value);
                 let imm_value = imm_value as u32;
@@ -225,7 +225,7 @@ macro_rules! decl_immediate {
                 T::from(imm_value & mask).unwrap()
             }
 
-            pub fn v64<T: num::NumCast>(imm_value: i64) -> T {
+            pub fn v64<T: num_traits::NumCast>(imm_value: i64) -> T {
                 assert!(Self::is_valid(imm_value));
                 let imm_value = imm_value as u64;
                 let mask: u64 = Self::immediate_mask::<u64>();
@@ -241,7 +241,7 @@ macro_rules! decl_immediate {
             $ctor
         }
 
-        impl num::ToPrimitive for $name {
+        impl num_traits::ToPrimitive for $name {
             fn to_i64(&self) -> Option<i64> {
                 Some(self.value as i64)
             }
@@ -259,9 +259,9 @@ macro_rules! decl_immediate {
             }
         }
 
-        impl num::NumCast for $name {
+        impl num_traits::NumCast for $name {
             fn from<T>(n: T) -> Option<Self>
-            where T: num::ToPrimitive
+            where T: num_traits::ToPrimitive
             {
                 let n = n.to_u32()?;
                 if Self::is_valid(n) {


### PR DESCRIPTION
- several were unused
- capstone was out of date (needed no changes)
- num was used when num_traits (which was already present) would work
- paste is only needed on riscv
- once_cell and parking_lot aren't as useful anymore now that std got better
